### PR TITLE
fix sid generation in cookie middleware

### DIFF
--- a/src/Middleware/SessionCookieMiddleware.php
+++ b/src/Middleware/SessionCookieMiddleware.php
@@ -27,7 +27,7 @@ class SessionCookieMiddleware implements MiddlewareInterface
 
         // Read the session cookie
         $cookies = $request->getCookieParams();
-        $sid = $cookies[$manager->name()] ?? '';
+        $sid = $cookies[$manager->name()] ?? null;
         $manager->id($sid);
 
         // Handle the request


### PR DESCRIPTION
I had to change this in order for **sid** generation to work. 

Is there a specific reason for using the translated native sid generation from the session extension?
I feel a normal random string generator would be better. And ignore `session.sid_length` and `session.sid_bits_per_character`.