### PR TITLE
set default SameSite config value to 'Lax'

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -251,7 +251,7 @@ class Config
         return $this->cookie_httponly;
     }
 
-    protected string $cookie_samesite = '';
+    protected string $cookie_samesite = 'Lax';
 
     public function setCookieSameSite(string $cookie_samesite): self
     {


### PR DESCRIPTION
Firefox threw this warning in my devtools during cookie creation:
```
Cookie “PHPSESSID” does not have a proper “SameSite” attribute value. Soon, cookies without the “SameSite” attribute or with an invalid value will be treated as “Lax”. This means that the cookie will no longer be sent in third-party contexts. If your application depends on this cookie being available in such contexts, please add the “SameSite=None“ attribute to it. To know more about the “SameSite“ attribute, read https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite
```

This update fixes that and future-proofs it. 