### PR TITLE
fix: add ArrayAccess to Session class

### DIFF
--- a/features/access.feature
+++ b/features/access.feature
@@ -2,19 +2,28 @@ Feature: Session access
   Scenario: Check data does not exist
     When data does not exist
     Then property check returns false
+    And array access check returns false
   Scenario: Check data exist
     When data exists
     Then property check returns true
+    And array access check returns true
   Scenario: Read data that exists
     When data exists
     Then property read returns data
+    And array access read returns data
   Scenario: Read data that does not exist
     When data does not exist
     Then property read triggers error
     And property read returns null
+    And array access read triggers error
+    And array access read returns null
   Scenario: Null coalesce when data does not exist
     When data does not exist
     Then property read with null coalesce returns null
-  Scenario: Write data
+    And array access read with null coalesce returns null
+  Scenario: Write property data
     When data does not exist
     Then property write succeeds
+  Scenario: Write array access data
+    When data does not exist
+    Then array access write succeeds

--- a/src/Session.php
+++ b/src/Session.php
@@ -51,15 +51,7 @@ class Session implements ArrayAccess, Countable
             throw new RuntimeException('Session not initialized');
         }
 
-<<<<<<< HEAD
         // @phpstan-ignore-next-line
-=======
-        if (!isset($this->contents[$name])) {
-            \trigger_error('Undefined property: ' . self::class . '::$' . $name, \E_USER_WARNING);
-            return null;
-        }
-
->>>>>>> 75ce8a0 (add ArrayAccess to Session class + throw error on invalid property retrieval)
         return $this->contents[$name];
     }
 
@@ -99,11 +91,6 @@ class Session implements ArrayAccess, Countable
             throw new RuntimeException('Cannot alter session after it is closed');
         }
 
-        if (!isset($this->contents[$name])) {
-            \trigger_error('Undefined property: ' . self::class . '::$' . $name, \E_USER_WARNING);
-            return;
-        }
-
         $this->modified = true;
         unset($this->contents[$name]);
     }
@@ -141,22 +128,12 @@ class Session implements ArrayAccess, Countable
             throw new RuntimeException('Cannot alter session after it is closed');
         }
 
-        if (!isset($this->contents[$name])) {
-            \trigger_error('Undefined array key "' . $name . '"', \E_USER_WARNING);
-            return;
-        }
-
         $this->modified = true;
         unset($this->contents[$name]);
     }
 
     public function offsetGet($name): mixed
     {
-        if (!isset($this->contents[$name])) {
-            \trigger_error('Undefined array key "' . $name . '"', \E_USER_WARNING);
-            return null;
-        }
-
         return $this->contents[$name];
     }
 

--- a/tests/behavior/AccessContext.php
+++ b/tests/behavior/AccessContext.php
@@ -101,4 +101,72 @@ class AccessContext implements Context
         Assert::assertCount(1, $this->session);
         Assert::assertTrue(isset($this->session->bar));
     }
+
+    /**
+     * @Then array access check returns true
+     */
+    public function arrayAccessCheckReturnsTrue(): void
+    {
+        Assert::assertTrue(isset($this->session['foo']));
+    }
+
+    /**
+     * @Then array access check returns false
+     */
+    public function arrayAccessCheckReturnsFalse(): void
+    {
+        Assert::assertFalse(isset($this->session['foo']));
+    }
+
+    /**
+     * @Then array access read returns data
+     */
+    public function arrayAccessReadReturnsData(): void
+    {
+        Assert::assertEquals('bar', $this->session['foo']);
+    }
+
+    /**
+     * @Then array access read triggers error
+     */
+    public function arrayAccessReadTriggersNoticeError(): void
+    {
+        try {
+            $errorThrown = false;
+            $bar = $this->session['bar'];
+            // @phpstan-ignore-next-line
+        } catch (Throwable $e) {
+            $errorThrown = true;
+        } finally {
+            Assert::assertTrue($errorThrown);
+        }
+    }
+
+    /**
+     * @Then array access read returns null
+     */
+    public function arrayAccessReadReturnsNull(): void
+    {
+        $bar = @$this->session['foo'];
+        Assert::assertSame(null, $bar);
+    }
+
+    /**
+     * @Then array access read with null coalesce returns null
+     */
+    public function arrayAccessReadWithNullCoalesceReturnsNull(): void
+    {
+        $bar = $this->session['foo'] ?? null;
+        Assert::assertSame(null, $bar);
+    }
+
+    /**
+     * @Then array access write succeeds
+     */
+    public function arrayAccessWriteSucceeds(): void
+    {
+        $this->session['bar'] = 'baz';
+        Assert::assertCount(1, $this->session);
+        Assert::assertTrue(isset($this->session['bar']));
+    }
 }


### PR DESCRIPTION
This PR implements \ArrayAccess (#4)

The class now also triggers an error on retrieval of non-existing properties and array keys. This is consistent with original PHP behaviour. Retrieval still returns null when the error is triggered as this is also original behaviour. I had to use `E_USER_WARNING` instead of `E_WARNING` though. Would it be wise to change them to Exceptions? 

I'm unsure where to add decent testing. I didn't find any tests for testing properties themselves. Should it go into `PersistenceContext` or a new test file?