### PR TITLE
feat: make Session iterable

### DIFF
--- a/features/access.feature
+++ b/features/access.feature
@@ -27,3 +27,6 @@ Feature: Session access
   Scenario: Write array access data
     When data does not exist
     Then array access write succeeds
+  Scenario: Loop over session variables
+    When data exists
+    Then loop succeeds

--- a/features/access.feature
+++ b/features/access.feature
@@ -27,6 +27,9 @@ Feature: Session access
   Scenario: Write array access data
     When data does not exist
     Then array access write succeeds
-  Scenario: Loop over session variables
+  Scenario: Iterate over populated session
     When data exists
-    Then loop succeeds
+    Then data is iterated
+  Scenario: Iterate over non-populated session
+    When data does not exist
+    Then data is not iterated

--- a/src/Session.php
+++ b/src/Session.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Compwright\PhpSession;
 
+use Iterator;
 use Countable;
 use ArrayAccess;
 use RuntimeException;
 
-class Session implements ArrayAccess, Countable
+class Session implements ArrayAccess, Iterator, Countable
 {
     protected string $name;
 
@@ -221,6 +222,31 @@ class Session implements ArrayAccess, Countable
         }
 
         return $this->contents ?? [];
+    }
+
+    public function rewind(): void
+    {
+        reset($this->contents);
+    }
+
+    public function current(): mixed
+    {
+        return current($this->contents);
+    }
+
+    public function key(): mixed
+    {
+        return key($this->contents);
+    }
+
+    public function next(): void
+    {
+        next($this->contents);
+    }
+
+    public function valid(): bool
+    {
+        return key($this->contents) !== null;
     }
 
     public function count(): int

--- a/src/Session.php
+++ b/src/Session.php
@@ -226,26 +226,46 @@ class Session implements ArrayAccess, Iterator, Countable
 
     public function rewind(): void
     {
+        if (!$this->isInitialized()) {
+            throw new RuntimeException('Session not initialized');
+        }
+        
         reset($this->contents);
     }
 
     public function current(): mixed
     {
+        if (!$this->isInitialized()) {
+            throw new RuntimeException('Session not initialized');
+        }
+        
         return current($this->contents);
     }
 
     public function key(): mixed
     {
+        if (!$this->isInitialized()) {
+            throw new RuntimeException('Session not initialized');
+        }
+        
         return key($this->contents);
     }
 
     public function next(): void
     {
+        if (!$this->isInitialized()) {
+            throw new RuntimeException('Session not initialized');
+        }
+        
         next($this->contents);
     }
 
     public function valid(): bool
     {
+        if (!$this->isInitialized()) {
+            throw new RuntimeException('Session not initialized');
+        }
+        
         return key($this->contents) !== null;
     }
 

--- a/src/Session.php
+++ b/src/Session.php
@@ -229,7 +229,8 @@ class Session implements ArrayAccess, Iterator, Countable
         if (!$this->isInitialized()) {
             throw new RuntimeException('Session not initialized');
         }
-        
+
+        // @phpstan-ignore-next-line
         reset($this->contents);
     }
 
@@ -238,7 +239,8 @@ class Session implements ArrayAccess, Iterator, Countable
         if (!$this->isInitialized()) {
             throw new RuntimeException('Session not initialized');
         }
-        
+
+        // @phpstan-ignore-next-line
         return current($this->contents);
     }
 
@@ -247,7 +249,8 @@ class Session implements ArrayAccess, Iterator, Countable
         if (!$this->isInitialized()) {
             throw new RuntimeException('Session not initialized');
         }
-        
+
+        // @phpstan-ignore-next-line
         return key($this->contents);
     }
 
@@ -256,7 +259,8 @@ class Session implements ArrayAccess, Iterator, Countable
         if (!$this->isInitialized()) {
             throw new RuntimeException('Session not initialized');
         }
-        
+
+        // @phpstan-ignore-next-line
         next($this->contents);
     }
 
@@ -265,7 +269,8 @@ class Session implements ArrayAccess, Iterator, Countable
         if (!$this->isInitialized()) {
             throw new RuntimeException('Session not initialized');
         }
-        
+
+        // @phpstan-ignore-next-line
         return key($this->contents) !== null;
     }
 

--- a/tests/behavior/AccessContext.php
+++ b/tests/behavior/AccessContext.php
@@ -171,9 +171,9 @@ class AccessContext implements Context
     }
 
     /**
-     * @Then loop succeeds
+     * @Then data is iterated
      */
-    public function loopSucceeds(): void
+    public function iteratorSucceeds(): void
     {
         $counter = 0;
 
@@ -184,5 +184,19 @@ class AccessContext implements Context
         }
 
         Assert::assertSame(1, $counter);
+    }
+
+    /**
+     * @Then data is not iterated
+     */
+    public function iteratorFails(): void
+    {
+        $counter = 0;
+
+        foreach ($this->session as $var => $val) {
+            $counter++;
+        }
+
+        Assert::assertSame(0, $counter);
     }
 }

--- a/tests/behavior/AccessContext.php
+++ b/tests/behavior/AccessContext.php
@@ -169,4 +169,20 @@ class AccessContext implements Context
         Assert::assertCount(1, $this->session);
         Assert::assertTrue(isset($this->session['bar']));
     }
+
+    /**
+     * @Then loop succeeds
+     */
+    public function loopSucceeds(): void
+    {
+        $counter = 0;
+
+        foreach ($this->session as $var => $val) {
+            Assert::assertSame('foo', $var);
+            Assert::assertSame('bar', $val);
+            $counter++;
+        }
+
+        Assert::assertSame(1, $counter);
+    }
 }


### PR DESCRIPTION
Implemented `\Iterator` interface into `Session` class.  
The `\Iterator` interface is what makes `foreach()` work.   
Also added a testing scenario. 

Closes my own issue: https://github.com/compwright/php-session/issues/10

Still wondering if `Serializable` is worth implementing.

